### PR TITLE
Updated to Numpy 2.0 Standard

### DIFF
--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -4,6 +4,14 @@ Changelog
 All notable changes to this project will be documented in this file.  This
 project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.html>`_.
 
+Version 3.1.1
+--------------
+
+Fix:
+
+  * Float type has been adjust to be consistent with new NumPy standard.
+
+
 Version 3.1.0
 --------------
 

--- a/wnutils/__about__.py
+++ b/wnutils/__about__.py
@@ -11,6 +11,6 @@ __all__ = [
 
 __title__ = "wnutils"
 __summary__ = "Python project to read and plot webnucleo files"
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 __author__ = "Clemson University"
 __copyright__ = "Clemson University, 2018-2023"

--- a/wnutils/h5.py
+++ b/wnutils/h5.py
@@ -272,7 +272,7 @@ class H5(wnb.Base):
         props = self.get_zone_properties_in_groups(zone, properties)
 
         for key, value in props.items():
-            result[key] = np.array(value, np.float_)
+            result[key] = np.array(value, np.float64)
 
         return result
 
@@ -332,7 +332,7 @@ class H5(wnb.Base):
         props = self.get_group_properties_in_zones(group, properties)
 
         for key, value in props.items():
-            result[key] = np.array(value, np.float_)
+            result[key] = np.array(value, np.float64)
 
         return result
 

--- a/wnutils/xml.py
+++ b/wnutils/xml.py
@@ -701,7 +701,7 @@ class Xml(wb.Base):
         props = self.get_properties(properties, zone_xpath)
 
         for prop in props:
-            props[prop] = np.array(props[prop], np.float_)
+            props[prop] = np.array(props[prop], np.float64)
 
         return props
 


### PR DESCRIPTION
Upgraded float types to be in accordance to new Numpy 2.0 standard. It's backwards compatible with previous versions of numpy. Also bumped version number